### PR TITLE
모바일 레이아웃 개선 및 소개 섹션 추가

### DIFF
--- a/index.html
+++ b/index.html
@@ -127,10 +127,18 @@
                 </div>
             </div>
 
+            <!-- Intro Section -->
+            <div class="bg-black/40 backdrop-blur-sm border-b border-gray-700 p-4 text-sm leading-relaxed">
+                <p class="text-gray-300">
+                    환영합니다, 모험가! 이 텍스트 기반 RPG에서 다양한 장소를 탐험하고 몬스터와 싸워보세요.
+                    아래 로그는 세계에서 벌어지는 일을 보여주며, 오른쪽 패널의 버튼으로 캐릭터를 조작할 수 있습니다.
+                </p>
+            </div>
+
             <!-- Main Content Area -->
-            <div class="flex-1 flex">
+            <div class="flex-1 flex flex-col md:flex-row p-4 gap-4">
                 <!-- Game Log -->
-                <div class="flex-1 p-4">
+                <div class="flex-1">
                     <div class="bg-black/40 rounded-lg border border-gray-600 h-full flex flex-col">
                         <div class="flex justify-between items-center p-4 border-b border-gray-600">
                             <h3 class="text-lg font-bold text-game-accent">게임 로그</h3>
@@ -145,7 +153,7 @@
                 </div>
 
                 <!-- Right Panel - Movement & Items -->
-                <div class="w-80 bg-game-card/80 backdrop-blur-sm border-l border-gray-700 p-4 space-y-4">
+                <div class="w-full md:w-80 bg-game-card/80 backdrop-blur-sm border-t md:border-t-0 md:border-l border-gray-700 p-4 space-y-4 h-1/2 md:h-auto overflow-y-auto">
                     <!-- Movement Controls -->
                     <div class="bg-black/40 rounded-lg p-4 border border-gray-600">
                         <h3 class="text-lg font-bold text-game-accent mb-3">이동</h3>


### PR DESCRIPTION
## 요약
- 모바일 대응을 위해 중앙 영역을 세로 배열로 전환하고 우측 패널 크기를 반응형으로 수정
- 상단에 게임 소개 섹션을 추가하여 초기 콘텐츠 보강

## 테스트
- `pytest`
- `python -m py_compile $(git ls-files '*.py')`
- `pip install flake8` *(네트워크 제한으로 실패)*

------
https://chatgpt.com/codex/tasks/task_e_688e06475ec8832cb9f957a5aa192aed