### PR TITLE
Improve mobile layout responsiveness

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,345 +1,480 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="ko">
-<head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>환상의 세계 MUD</title>
     <script src="https://cdn.tailwindcss.com"></script>
     <script>
-        tailwind.config = {
-            theme: {
-                extend: {
-                    colors: {
-                        'game-dark': '#0a0a0f',
-                        'game-card': '#1a1a2e',
-                        'game-accent': '#00d4ff',
-                        'game-danger': '#ff6b6b',
-                        'game-success': '#51cf66',
-                        'game-warning': '#ffd43b'
-                    },
-                    fontFamily: {
-                        'game': ['Inter', 'sans-serif'],
-                        'mono': ['JetBrains Mono', 'monospace']
-                    }
-                }
-            }
-        }
+      tailwind.config = {
+        theme: {
+          extend: {
+            colors: {
+              "game-dark": "#0a0a0f",
+              "game-card": "#1a1a2e",
+              "game-accent": "#00d4ff",
+              "game-danger": "#ff6b6b",
+              "game-success": "#51cf66",
+              "game-warning": "#ffd43b",
+            },
+            fontFamily: {
+              game: ["Inter", "sans-serif"],
+              mono: ["JetBrains Mono", "monospace"],
+            },
+          },
+        },
+      };
     </script>
-    <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90'>🎮</text></svg>">
-</head>
-<body class="bg-gradient-to-br from-game-dark to-gray-900 text-white font-game min-h-screen overflow-hidden">
+    <link
+      rel="icon"
+      href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90'>🎮</text></svg>"
+    />
+  </head>
+  <body
+    class="bg-gradient-to-br from-game-dark to-gray-900 text-white font-game min-h-screen"
+  >
     <!-- Main Game Interface -->
-    <div class="flex flex-col md:flex-row h-screen">
-        <!-- Left Panel - Character & Status -->
-        <div class="w-full md:w-80 bg-game-card/80 backdrop-blur-sm border-b md:border-b-0 md:border-r border-gray-700 p-4 space-y-4 overflow-y-auto h-1/2 md:h-auto">
-            <!-- Character Status -->
-            <div class="bg-black/40 rounded-lg p-4 border border-gray-600">
-                <h3 class="text-lg font-bold text-game-accent mb-3">캐릭터 정보</h3>
-                <div class="space-y-2">
-                    <div class="flex justify-between">
-                        <span class="text-gray-300">레벨</span>
-                        <span id="player-level" class="text-white font-bold">1</span>
-                    </div>
-                    <div class="flex justify-between">
-                        <span class="text-gray-300">체력</span>
-                        <span id="player-hp" class="text-white font-bold">100/100</span>
-                    </div>
-                    <div class="flex justify-between">
-                        <span class="text-gray-300">경험치</span>
-                        <span id="player-exp" class="text-white font-bold">0/100</span>
-                    </div>
-                    <div class="flex justify-between">
-                        <span class="text-gray-300">공격력</span>
-                        <span id="player-attack" class="text-white font-bold">10</span>
-                    </div>
-                    <div class="flex justify-between">
-                        <span class="text-gray-300">방어력</span>
-                        <span id="player-defense" class="text-white font-bold">5</span>
-                    </div>
-                    <div class="flex justify-between">
-                        <span class="text-gray-300">골드</span>
-                        <span id="player-gold" class="text-game-warning font-bold">0</span>
-                    </div>
-                </div>
+    <div class="flex flex-col md:flex-row min-h-screen">
+      <!-- Left Panel - Character & Status -->
+      <div
+        class="w-full md:w-80 bg-game-card/80 backdrop-blur-sm border-b md:border-b-0 md:border-r border-gray-700 p-4 space-y-4 md:overflow-y-auto md:h-auto"
+      >
+        <!-- Character Status -->
+        <div class="bg-black/40 rounded-lg p-4 border border-gray-600">
+          <h3 class="text-lg font-bold text-game-accent mb-3">캐릭터 정보</h3>
+          <div class="space-y-2">
+            <div class="flex justify-between">
+              <span class="text-gray-300">레벨</span>
+              <span id="player-level" class="text-white font-bold">1</span>
             </div>
-
-            <!-- Current Location -->
-            <div class="bg-black/40 rounded-lg p-4 border border-gray-600">
-                <h3 class="text-lg font-bold text-game-accent mb-3">현재 위치</h3>
-                <div class="space-y-2">
-                    <div>
-                        <span class="text-gray-300">장소:</span>
-                        <span id="current-room-name" class="text-white font-bold block">시작의 마을</span>
-                    </div>
-                    <div>
-                        <span class="text-gray-300">출구:</span>
-                        <span id="available-exits" class="text-white block">북, 남, 서, 동</span>
-                    </div>
-                    <div>
-                        <span class="text-gray-300">아이템:</span>
-                        <span id="room-items" class="text-white block">없음</span>
-                    </div>
-                    <div>
-                        <span class="text-gray-300">NPC:</span>
-                        <span id="room-npcs" class="text-white block">없음</span>
-                    </div>
-                    <div>
-                        <span class="text-gray-300">몬스터:</span>
-                        <span id="room-monsters" class="text-white block">없음</span>
-                    </div>
-                </div>
+            <div class="flex justify-between">
+              <span class="text-gray-300">체력</span>
+              <span id="player-hp" class="text-white font-bold">100/100</span>
             </div>
-
-            <!-- Quick Actions -->
-            <div class="bg-black/40 rounded-lg p-4 border border-gray-600">
-                <h3 class="text-lg font-bold text-game-accent mb-3">빠른 액션</h3>
-                <div class="grid grid-cols-2 gap-2">
-                    <button id="inspect-button" class="bg-gray-700 hover:bg-gray-600 rounded p-2 text-sm transition-colors">
-                        🔍 주변
-                    </button>
-                    <button id="toggle-map-button" class="bg-gray-700 hover:bg-gray-600 rounded p-2 text-sm transition-colors">
-                        🗺️ 지도
-                    </button>
-                    <button id="attack-button" class="bg-game-danger hover:bg-red-600 rounded p-2 text-sm transition-colors disabled:opacity-50 disabled:cursor-not-allowed" disabled>
-                        ⚔️ 공격
-                    </button>
-                    <button id="inventory-button" class="bg-gray-700 hover:bg-gray-600 rounded p-2 text-sm transition-colors">
-                        🎒 인벤토리
-                    </button>
-                </div>
+            <div class="flex justify-between">
+              <span class="text-gray-300">경험치</span>
+              <span id="player-exp" class="text-white font-bold">0/100</span>
             </div>
+            <div class="flex justify-between">
+              <span class="text-gray-300">공격력</span>
+              <span id="player-attack" class="text-white font-bold">10</span>
+            </div>
+            <div class="flex justify-between">
+              <span class="text-gray-300">방어력</span>
+              <span id="player-defense" class="text-white font-bold">5</span>
+            </div>
+            <div class="flex justify-between">
+              <span class="text-gray-300">골드</span>
+              <span id="player-gold" class="text-game-warning font-bold"
+                >0</span
+              >
+            </div>
+          </div>
         </div>
 
-        <!-- Center Panel - Main Game Area -->
-        <div class="flex-1 flex flex-col">
-            <!-- Top Bar -->
-            <div class="bg-black/40 backdrop-blur-sm border-b border-gray-700 p-4">
-                <div class="flex justify-between items-center">
-                    <h1 class="text-2xl font-bold text-game-accent">환상의 세계 MUD</h1>
-                    <div class="flex space-x-2">
-                        <button id="settings-button" class="bg-gray-700 hover:bg-gray-600 rounded p-2 transition-colors">
-                            ⚙️ 설정
-                        </button>
-                        <button id="help-button" class="bg-gray-700 hover:bg-gray-600 rounded p-2 transition-colors">
-                            ❓ 도움말
-                        </button>
-                    </div>
-                </div>
+        <!-- Current Location -->
+        <div class="bg-black/40 rounded-lg p-4 border border-gray-600">
+          <h3 class="text-lg font-bold text-game-accent mb-3">현재 위치</h3>
+          <div class="space-y-2">
+            <div>
+              <span class="text-gray-300">장소:</span>
+              <span id="current-room-name" class="text-white font-bold block"
+                >시작의 마을</span
+              >
             </div>
-
-            <!-- Intro Section -->
-            <div class="bg-black/40 backdrop-blur-sm border-b border-gray-700 p-4 text-sm leading-relaxed">
-                <p class="text-gray-300">
-                    환영합니다, 모험가! 이 텍스트 기반 RPG에서 다양한 장소를 탐험하고 몬스터와 싸워보세요.
-                    아래 로그는 세계에서 벌어지는 일을 보여주며, 오른쪽 패널의 버튼으로 캐릭터를 조작할 수 있습니다.
-                </p>
+            <div>
+              <span class="text-gray-300">출구:</span>
+              <span id="available-exits" class="text-white block"
+                >북, 남, 서, 동</span
+              >
             </div>
-
-            <!-- Main Content Area -->
-            <div class="flex-1 flex flex-col md:flex-row p-4 gap-4">
-                <!-- Game Log -->
-                <div class="flex-1">
-                    <div class="bg-black/40 rounded-lg border border-gray-600 h-full flex flex-col">
-                        <div class="flex justify-between items-center p-4 border-b border-gray-600">
-                            <h3 class="text-lg font-bold text-game-accent">게임 로그</h3>
-                            <button id="clear-log" class="bg-gray-700 hover:bg-gray-600 rounded p-2 transition-colors">
-                                🗑️ 지우기
-                            </button>
-                        </div>
-                        <div id="log-window" class="flex-1 p-4 overflow-y-auto space-y-2 text-sm">
-                            <div class="text-gray-400">게임이 시작되었습니다...</div>
-                        </div>
-                    </div>
-                </div>
-
-                <!-- Right Panel - Movement & Items -->
-                <div class="w-full md:w-80 bg-game-card/80 backdrop-blur-sm border-t md:border-t-0 md:border-l border-gray-700 p-4 space-y-4 h-1/2 md:h-auto overflow-y-auto">
-                    <!-- Movement Controls -->
-                    <div class="bg-black/40 rounded-lg p-4 border border-gray-600">
-                        <h3 class="text-lg font-bold text-game-accent mb-3">이동</h3>
-                        <div class="grid grid-cols-2 gap-2">
-                            <button class="btn-direction bg-gray-700 hover:bg-gray-600 rounded p-3 transition-colors" data-dir="북">
-                                <div class="text-center">
-                                    <div class="text-2xl">⬆️</div>
-                                    <div class="text-sm">북</div>
-                                </div>
-                            </button>
-                            <button class="btn-direction bg-gray-700 hover:bg-gray-600 rounded p-3 transition-colors" data-dir="남">
-                                <div class="text-center">
-                                    <div class="text-2xl">⬇️</div>
-                                    <div class="text-sm">남</div>
-                                </div>
-                            </button>
-                            <button class="btn-direction bg-gray-700 hover:bg-gray-600 rounded p-3 transition-colors" data-dir="서">
-                                <div class="text-center">
-                                    <div class="text-2xl">⬅️</div>
-                                    <div class="text-sm">서</div>
-                                </div>
-                            </button>
-                            <button class="btn-direction bg-gray-700 hover:bg-gray-600 rounded p-3 transition-colors" data-dir="동">
-                                <div class="text-center">
-                                    <div class="text-2xl">➡️</div>
-                                    <div class="text-sm">동</div>
-                                </div>
-                            </button>
-                        </div>
-                    </div>
-
-                    <!-- Room Items -->
-                    <div class="bg-black/40 rounded-lg p-4 border border-gray-600">
-                        <h3 class="text-lg font-bold text-game-accent mb-3">방 아이템</h3>
-                        <div id="item-buttons" class="space-y-2">
-                            <div class="text-gray-400 text-sm">아이템이 없습니다</div>
-                        </div>
-                    </div>
-
-                    <!-- Inventory -->
-                    <div class="bg-black/40 rounded-lg p-4 border border-gray-600">
-                        <h3 class="text-lg font-bold text-game-accent mb-3">인벤토리</h3>
-                        <div id="inventory-buttons" class="space-y-2">
-                            <div class="text-gray-400 text-sm">비어있습니다</div>
-                        </div>
-                    </div>
-                </div>
+            <div>
+              <span class="text-gray-300">아이템:</span>
+              <span id="room-items" class="text-white block">없음</span>
             </div>
+            <div>
+              <span class="text-gray-300">NPC:</span>
+              <span id="room-npcs" class="text-white block">없음</span>
+            </div>
+            <div>
+              <span class="text-gray-300">몬스터:</span>
+              <span id="room-monsters" class="text-white block">없음</span>
+            </div>
+          </div>
         </div>
+
+        <!-- Quick Actions -->
+        <div class="bg-black/40 rounded-lg p-4 border border-gray-600">
+          <h3 class="text-lg font-bold text-game-accent mb-3">빠른 액션</h3>
+          <div class="grid grid-cols-2 gap-2">
+            <button
+              id="inspect-button"
+              class="bg-gray-700 hover:bg-gray-600 rounded p-2 text-sm transition-colors"
+            >
+              🔍 주변
+            </button>
+            <button
+              id="toggle-map-button"
+              class="bg-gray-700 hover:bg-gray-600 rounded p-2 text-sm transition-colors"
+            >
+              🗺️ 지도
+            </button>
+            <button
+              id="attack-button"
+              class="bg-game-danger hover:bg-red-600 rounded p-2 text-sm transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+              disabled
+            >
+              ⚔️ 공격
+            </button>
+            <button
+              id="inventory-button"
+              class="bg-gray-700 hover:bg-gray-600 rounded p-2 text-sm transition-colors"
+            >
+              🎒 인벤토리
+            </button>
+          </div>
+        </div>
+      </div>
+
+      <!-- Center Panel - Main Game Area -->
+      <div class="flex-1 flex flex-col">
+        <!-- Top Bar -->
+        <div class="bg-black/40 backdrop-blur-sm border-b border-gray-700 p-4">
+          <div
+            class="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between"
+          >
+            <h1 class="text-2xl font-bold text-game-accent">환상의 세계 MUD</h1>
+            <div class="flex gap-2 sm:justify-end">
+              <button
+                id="settings-button"
+                class="bg-gray-700 hover:bg-gray-600 rounded p-2 transition-colors"
+              >
+                ⚙️ 설정
+              </button>
+              <button
+                id="help-button"
+                class="bg-gray-700 hover:bg-gray-600 rounded p-2 transition-colors"
+              >
+                ❓ 도움말
+              </button>
+            </div>
+          </div>
+        </div>
+
+        <!-- Intro Section -->
+        <div
+          class="bg-black/40 backdrop-blur-sm border-b border-gray-700 p-4 text-sm md:text-base leading-relaxed"
+        >
+          <p class="text-gray-300">
+            환영합니다, 모험가! 이 텍스트 기반 RPG에서 다양한 장소를 탐험하고
+            몬스터와 싸워보세요. 아래 로그는 세계에서 벌어지는 일을 보여주며,
+            오른쪽 패널의 버튼으로 캐릭터를 조작할 수 있습니다.
+          </p>
+        </div>
+
+        <!-- Main Content Area -->
+        <div class="flex-1 flex flex-col md:flex-row p-4 gap-4">
+          <!-- Game Log -->
+          <div class="flex-1">
+            <div
+              class="bg-black/40 rounded-lg border border-gray-600 h-full min-h-[320px] flex flex-col"
+            >
+              <div
+                class="flex justify-between items-center p-4 border-b border-gray-600"
+              >
+                <h3 class="text-lg font-bold text-game-accent">게임 로그</h3>
+                <button
+                  id="clear-log"
+                  class="bg-gray-700 hover:bg-gray-600 rounded p-2 transition-colors"
+                >
+                  🗑️ 지우기
+                </button>
+              </div>
+              <div
+                id="log-window"
+                class="flex-1 p-4 overflow-y-auto space-y-2 text-sm"
+              >
+                <div class="text-gray-400">게임이 시작되었습니다...</div>
+              </div>
+            </div>
+          </div>
+
+          <!-- Right Panel - Movement & Items -->
+          <div
+            class="w-full md:w-80 bg-game-card/80 backdrop-blur-sm border-t md:border-t-0 md:border-l border-gray-700 p-4 space-y-4 md:h-auto md:overflow-y-auto"
+          >
+            <!-- Movement Controls -->
+            <div class="bg-black/40 rounded-lg p-4 border border-gray-600">
+              <h3 class="text-lg font-bold text-game-accent mb-3">이동</h3>
+              <div class="grid grid-cols-2 gap-2">
+                <button
+                  class="btn-direction bg-gray-700 hover:bg-gray-600 rounded p-3 transition-colors"
+                  data-dir="북"
+                >
+                  <div class="text-center">
+                    <div class="text-2xl">⬆️</div>
+                    <div class="text-sm">북</div>
+                  </div>
+                </button>
+                <button
+                  class="btn-direction bg-gray-700 hover:bg-gray-600 rounded p-3 transition-colors"
+                  data-dir="남"
+                >
+                  <div class="text-center">
+                    <div class="text-2xl">⬇️</div>
+                    <div class="text-sm">남</div>
+                  </div>
+                </button>
+                <button
+                  class="btn-direction bg-gray-700 hover:bg-gray-600 rounded p-3 transition-colors"
+                  data-dir="서"
+                >
+                  <div class="text-center">
+                    <div class="text-2xl">⬅️</div>
+                    <div class="text-sm">서</div>
+                  </div>
+                </button>
+                <button
+                  class="btn-direction bg-gray-700 hover:bg-gray-600 rounded p-3 transition-colors"
+                  data-dir="동"
+                >
+                  <div class="text-center">
+                    <div class="text-2xl">➡️</div>
+                    <div class="text-sm">동</div>
+                  </div>
+                </button>
+              </div>
+            </div>
+
+            <!-- Room Items -->
+            <div class="bg-black/40 rounded-lg p-4 border border-gray-600">
+              <h3 class="text-lg font-bold text-game-accent mb-3">방 아이템</h3>
+              <div id="item-buttons" class="space-y-2">
+                <div class="text-gray-400 text-sm">아이템이 없습니다</div>
+              </div>
+            </div>
+
+            <!-- Inventory -->
+            <div class="bg-black/40 rounded-lg p-4 border border-gray-600">
+              <h3 class="text-lg font-bold text-game-accent mb-3">인벤토리</h3>
+              <div id="inventory-buttons" class="space-y-2">
+                <div class="text-gray-400 text-sm">비어있습니다</div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
     </div>
 
     <!-- Combat Modal -->
-    <div id="combat-modal" class="fixed inset-0 bg-black/80 backdrop-blur-sm hidden items-center justify-center z-50">
-        <div class="bg-game-card border border-gray-600 rounded-lg p-6 w-96 max-w-md">
-            <div class="flex justify-between items-center mb-4">
-                <h3 class="text-xl font-bold text-game-accent">전투</h3>
-                <button id="close-combat" class="bg-gray-700 hover:bg-gray-600 rounded p-2 transition-colors">
-                    ✕
-                </button>
-            </div>
-            <div id="combat-ui" class="space-y-4">
-                <div class="space-y-3">
-                    <div class="bg-black/40 rounded p-3">
-                        <div class="flex justify-between items-center mb-2">
-                            <span class="font-bold text-white">플레이어</span>
-                            <span id="player-hp-bar-text" class="text-sm text-gray-300">100/100</span>
-                        </div>
-                        <div class="w-full bg-gray-700 rounded-full h-2">
-                            <div id="player-hp-bar" class="bg-game-success h-2 rounded-full transition-all duration-300" style="width: 100%"></div>
-                        </div>
-                    </div>
-                    <div class="bg-black/40 rounded p-3">
-                        <div class="flex justify-between items-center mb-2">
-                            <span class="font-bold text-white">몬스터</span>
-                            <span id="monster-hp-bar-text" class="text-sm text-gray-300">100/100</span>
-                        </div>
-                        <div class="w-full bg-gray-700 rounded-full h-2">
-                            <div id="monster-hp-bar" class="bg-game-danger h-2 rounded-full transition-all duration-300" style="width: 100%"></div>
-                        </div>
-                    </div>
-                </div>
-                <div class="flex space-x-2">
-                    <button id="combat-attack-button" class="flex-1 bg-game-danger hover:bg-red-600 rounded p-3 transition-colors font-bold">
-                        공격
-                    </button>
-                    <button id="combat-flee-button" class="flex-1 bg-gray-700 hover:bg-gray-600 rounded p-3 transition-colors">
-                        도망
-                    </button>
-                </div>
-            </div>
+    <div
+      id="combat-modal"
+      class="fixed inset-0 bg-black/80 backdrop-blur-sm hidden items-center justify-center z-50"
+    >
+      <div
+        class="bg-game-card border border-gray-600 rounded-lg p-6 w-11/12 max-w-md"
+      >
+        <div class="flex justify-between items-center mb-4">
+          <h3 class="text-xl font-bold text-game-accent">전투</h3>
+          <button
+            id="close-combat"
+            class="bg-gray-700 hover:bg-gray-600 rounded p-2 transition-colors"
+          >
+            ✕
+          </button>
         </div>
+        <div id="combat-ui" class="space-y-4">
+          <div class="space-y-3">
+            <div class="bg-black/40 rounded p-3">
+              <div class="flex justify-between items-center mb-2">
+                <span class="font-bold text-white">플레이어</span>
+                <span id="player-hp-bar-text" class="text-sm text-gray-300"
+                  >100/100</span
+                >
+              </div>
+              <div class="w-full bg-gray-700 rounded-full h-2">
+                <div
+                  id="player-hp-bar"
+                  class="bg-game-success h-2 rounded-full transition-all duration-300"
+                  style="width: 100%"
+                ></div>
+              </div>
+            </div>
+            <div class="bg-black/40 rounded p-3">
+              <div class="flex justify-between items-center mb-2">
+                <span class="font-bold text-white">몬스터</span>
+                <span id="monster-hp-bar-text" class="text-sm text-gray-300"
+                  >100/100</span
+                >
+              </div>
+              <div class="w-full bg-gray-700 rounded-full h-2">
+                <div
+                  id="monster-hp-bar"
+                  class="bg-game-danger h-2 rounded-full transition-all duration-300"
+                  style="width: 100%"
+                ></div>
+              </div>
+            </div>
+          </div>
+          <div class="flex space-x-2">
+            <button
+              id="combat-attack-button"
+              class="flex-1 bg-game-danger hover:bg-red-600 rounded p-3 transition-colors font-bold"
+            >
+              공격
+            </button>
+            <button
+              id="combat-flee-button"
+              class="flex-1 bg-gray-700 hover:bg-gray-600 rounded p-3 transition-colors"
+            >
+              도망
+            </button>
+          </div>
+        </div>
+      </div>
     </div>
 
     <!-- Map Modal -->
-    <div id="map-display" class="fixed inset-0 bg-black/80 backdrop-blur-sm hidden items-center justify-center z-50">
-        <div class="bg-game-card border border-gray-600 rounded-lg p-6 w-4/5 h-4/5 max-w-4xl">
-            <div class="flex justify-between items-center mb-4">
-                <h3 class="text-xl font-bold text-game-accent">월드 맵</h3>
-                <button id="close-map" class="bg-gray-700 hover:bg-gray-600 rounded p-2 transition-colors">
-                    ✕
-                </button>
-            </div>
-            <div class="bg-black/40 rounded p-4 h-full overflow-auto">
-                <pre id="map-grid" class="text-xs font-mono text-white"></pre>
-            </div>
+    <div
+      id="map-display"
+      class="fixed inset-0 bg-black/80 backdrop-blur-sm hidden items-center justify-center z-50"
+    >
+      <div
+        class="bg-game-card border border-gray-600 rounded-lg p-6 w-11/12 md:w-4/5 h-[75vh] md:h-4/5 max-w-4xl max-h-[90vh]"
+      >
+        <div class="flex justify-between items-center mb-4">
+          <h3 class="text-xl font-bold text-game-accent">월드 맵</h3>
+          <button
+            id="close-map"
+            class="bg-gray-700 hover:bg-gray-600 rounded p-2 transition-colors"
+          >
+            ✕
+          </button>
         </div>
+        <div class="bg-black/40 rounded p-4 h-full overflow-auto">
+          <pre id="map-grid" class="text-xs font-mono text-white"></pre>
+        </div>
+      </div>
     </div>
 
     <!-- Inventory Modal -->
-    <div id="inventory-modal" class="fixed inset-0 bg-black/80 backdrop-blur-sm hidden items-center justify-center z-50">
-        <div class="bg-game-card border border-gray-600 rounded-lg p-6 w-11/12 max-w-md">
-            <div class="flex justify-between items-center mb-4">
-                <h3 class="text-xl font-bold text-game-accent">인벤토리</h3>
-                <button id="close-inventory" class="bg-gray-700 hover:bg-gray-600 rounded p-2 transition-colors">
-                    ✕
-                </button>
-            </div>
-            <div id="inventory-content" class="space-y-2">
-                <div class="text-gray-400 text-center py-4">인벤토리가 비어있습니다</div>
-            </div>
+    <div
+      id="inventory-modal"
+      class="fixed inset-0 bg-black/80 backdrop-blur-sm hidden items-center justify-center z-50"
+    >
+      <div
+        class="bg-game-card border border-gray-600 rounded-lg p-6 w-11/12 max-w-md"
+      >
+        <div class="flex justify-between items-center mb-4">
+          <h3 class="text-xl font-bold text-game-accent">인벤토리</h3>
+          <button
+            id="close-inventory"
+            class="bg-gray-700 hover:bg-gray-600 rounded p-2 transition-colors"
+          >
+            ✕
+          </button>
         </div>
+        <div id="inventory-content" class="space-y-2">
+          <div class="text-gray-400 text-center py-4">
+            인벤토리가 비어있습니다
+          </div>
+        </div>
+      </div>
     </div>
 
     <!-- Settings Modal -->
-    <div id="settings-modal" class="fixed inset-0 bg-black/80 backdrop-blur-sm hidden items-center justify-center z-50">
-        <div class="bg-game-card border border-gray-600 rounded-lg p-6 w-11/12 max-w-md">
-            <div class="flex justify-between items-center mb-4">
-                <h3 class="text-xl font-bold text-game-accent">설정</h3>
-                <button id="close-settings" class="bg-gray-700 hover:bg-gray-600 rounded p-2 transition-colors">
-                    ✕
-                </button>
-            </div>
-            <div class="space-y-4">
-                <div>
-                    <label class="block text-sm font-medium text-gray-300 mb-2">사운드</label>
-                    <input type="range" min="0" max="100" value="50" class="w-full">
-                </div>
-                <div>
-                    <label class="block text-sm font-medium text-gray-300 mb-2">효과음</label>
-                    <input type="range" min="0" max="100" value="30" class="w-full">
-                </div>
-                <div class="flex items-center">
-                    <input type="checkbox" id="auto-save" class="mr-2">
-                    <label for="auto-save" class="text-sm text-gray-300">자동 저장</label>
-                </div>
-            </div>
+    <div
+      id="settings-modal"
+      class="fixed inset-0 bg-black/80 backdrop-blur-sm hidden items-center justify-center z-50"
+    >
+      <div
+        class="bg-game-card border border-gray-600 rounded-lg p-6 w-11/12 max-w-md"
+      >
+        <div class="flex justify-between items-center mb-4">
+          <h3 class="text-xl font-bold text-game-accent">설정</h3>
+          <button
+            id="close-settings"
+            class="bg-gray-700 hover:bg-gray-600 rounded p-2 transition-colors"
+          >
+            ✕
+          </button>
         </div>
+        <div class="space-y-4">
+          <div>
+            <label class="block text-sm font-medium text-gray-300 mb-2"
+              >사운드</label
+            >
+            <input type="range" min="0" max="100" value="50" class="w-full" />
+          </div>
+          <div>
+            <label class="block text-sm font-medium text-gray-300 mb-2"
+              >효과음</label
+            >
+            <input type="range" min="0" max="100" value="30" class="w-full" />
+          </div>
+          <div class="flex items-center">
+            <input type="checkbox" id="auto-save" class="mr-2" />
+            <label for="auto-save" class="text-sm text-gray-300"
+              >자동 저장</label
+            >
+          </div>
+        </div>
+      </div>
     </div>
 
     <!-- Help Modal -->
-    <div id="help-modal" class="fixed inset-0 bg-black/80 backdrop-blur-sm hidden items-center justify-center z-50">
-        <div class="bg-game-card border border-gray-600 rounded-lg p-6 w-11/12 max-w-md">
-            <div class="flex justify-between items-center mb-4">
-                <h3 class="text-xl font-bold text-game-accent">도움말</h3>
-                <button id="close-help" class="bg-gray-700 hover:bg-gray-600 rounded p-2 transition-colors">
-                    ✕
-                </button>
-            </div>
-            <div class="space-y-3 text-sm">
-                <div>
-                    <strong class="text-game-accent">이동:</strong> 방향 버튼 또는 WASD 키
-                </div>
-                <div>
-                    <strong class="text-game-accent">공격:</strong> 스페이스바 또는 공격 버튼
-                </div>
-                <div>
-                    <strong class="text-game-accent">주변 탐색:</strong> 주변 버튼
-                </div>
-                <div>
-                    <strong class="text-game-accent">지도:</strong> 지도 버튼 또는 M 키
-                </div>
-                <div>
-                    <strong class="text-game-accent">인벤토리:</strong> 인벤토리 버튼 또는 I 키
-                </div>
-            </div>
+    <div
+      id="help-modal"
+      class="fixed inset-0 bg-black/80 backdrop-blur-sm hidden items-center justify-center z-50"
+    >
+      <div
+        class="bg-game-card border border-gray-600 rounded-lg p-6 w-11/12 max-w-md"
+      >
+        <div class="flex justify-between items-center mb-4">
+          <h3 class="text-xl font-bold text-game-accent">도움말</h3>
+          <button
+            id="close-help"
+            class="bg-gray-700 hover:bg-gray-600 rounded p-2 transition-colors"
+          >
+            ✕
+          </button>
         </div>
+        <div class="space-y-3 text-sm">
+          <div>
+            <strong class="text-game-accent">이동:</strong> 방향 버튼 또는 WASD
+            키
+          </div>
+          <div>
+            <strong class="text-game-accent">공격:</strong> 스페이스바 또는 공격
+            버튼
+          </div>
+          <div>
+            <strong class="text-game-accent">주변 탐색:</strong> 주변 버튼
+          </div>
+          <div>
+            <strong class="text-game-accent">지도:</strong> 지도 버튼 또는 M 키
+          </div>
+          <div>
+            <strong class="text-game-accent">인벤토리:</strong> 인벤토리 버튼
+            또는 I 키
+          </div>
+        </div>
+      </div>
     </div>
 
     <!-- Loading Overlay -->
-    <div id="loading-overlay" class="fixed inset-0 bg-black/90 backdrop-blur-sm hidden items-center justify-center z-50">
-        <div class="text-center">
-            <div class="animate-spin rounded-full h-12 w-12 border-b-2 border-game-accent mx-auto mb-4"></div>
-            <div class="text-white text-lg">로딩 중...</div>
-        </div>
+    <div
+      id="loading-overlay"
+      class="fixed inset-0 bg-black/90 backdrop-blur-sm hidden items-center justify-center z-50"
+    >
+      <div class="text-center">
+        <div
+          class="animate-spin rounded-full h-12 w-12 border-b-2 border-game-accent mx-auto mb-4"
+        ></div>
+        <div class="text-white text-lg">로딩 중...</div>
+      </div>
     </div>
 
     <script type="module" src="main.js"></script>
-</body>
+  </body>
 </html>


### PR DESCRIPTION
## Summary
- relax full-height constraints and overflow settings so the interface can scroll naturally on mobile
- adjust header and log layout spacing to stack cleanly on small screens
- resize modal dialogs to fit comfortably within mobile viewports

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68ce7a031e50832cb10e444d0415f5b2