### PR TITLE
모바일 단일 화면 UI 재구성

### DIFF
--- a/index.html
+++ b/index.html
@@ -31,237 +31,330 @@
     />
   </head>
   <body
-    class="bg-gradient-to-br from-game-dark to-gray-900 text-white font-game min-h-screen"
+    class="bg-gradient-to-br from-game-dark to-gray-900 text-white font-game min-h-screen h-screen overflow-hidden"
   >
-    <!-- Main Game Interface -->
-    <div class="flex flex-col md:flex-row min-h-screen">
-      <!-- Left Panel - Character & Status -->
+    <div
+      class="min-h-screen h-full flex items-center justify-center p-4 sm:p-6"
+    >
       <div
-        class="w-full md:w-80 bg-game-card/80 backdrop-blur-sm border-b md:border-b-0 md:border-r border-gray-700 p-4 space-y-4 md:overflow-y-auto md:h-auto"
+        class="relative w-full h-full max-w-4xl bg-game-card/60 border border-gray-800 rounded-3xl overflow-hidden shadow-2xl"
       >
-        <!-- Character Status -->
-        <div class="bg-black/40 rounded-lg p-4 border border-gray-600">
-          <h3 class="text-lg font-bold text-game-accent mb-3">캐릭터 정보</h3>
-          <div class="space-y-2">
-            <div class="flex justify-between">
-              <span class="text-gray-300">레벨</span>
-              <span id="player-level" class="text-white font-bold">1</span>
-            </div>
-            <div class="flex justify-between">
-              <span class="text-gray-300">체력</span>
-              <span id="player-hp" class="text-white font-bold">100/100</span>
-            </div>
-            <div class="flex justify-between">
-              <span class="text-gray-300">경험치</span>
-              <span id="player-exp" class="text-white font-bold">0/100</span>
-            </div>
-            <div class="flex justify-between">
-              <span class="text-gray-300">공격력</span>
-              <span id="player-attack" class="text-white font-bold">10</span>
-            </div>
-            <div class="flex justify-between">
-              <span class="text-gray-300">방어력</span>
-              <span id="player-defense" class="text-white font-bold">5</span>
-            </div>
-            <div class="flex justify-between">
-              <span class="text-gray-300">골드</span>
-              <span id="player-gold" class="text-game-warning font-bold"
-                >0</span
-              >
-            </div>
-          </div>
-        </div>
-
-        <!-- Current Location -->
-        <div class="bg-black/40 rounded-lg p-4 border border-gray-600">
-          <h3 class="text-lg font-bold text-game-accent mb-3">현재 위치</h3>
-          <div class="space-y-2">
-            <div>
-              <span class="text-gray-300">장소:</span>
-              <span id="current-room-name" class="text-white font-bold block"
-                >시작의 마을</span
-              >
-            </div>
-            <div>
-              <span class="text-gray-300">출구:</span>
-              <span id="available-exits" class="text-white block"
-                >북, 남, 서, 동</span
-              >
-            </div>
-            <div>
-              <span class="text-gray-300">아이템:</span>
-              <span id="room-items" class="text-white block">없음</span>
-            </div>
-            <div>
-              <span class="text-gray-300">NPC:</span>
-              <span id="room-npcs" class="text-white block">없음</span>
-            </div>
-            <div>
-              <span class="text-gray-300">몬스터:</span>
-              <span id="room-monsters" class="text-white block">없음</span>
-            </div>
-          </div>
-        </div>
-
-        <!-- Quick Actions -->
-        <div class="bg-black/40 rounded-lg p-4 border border-gray-600">
-          <h3 class="text-lg font-bold text-game-accent mb-3">빠른 액션</h3>
-          <div class="grid grid-cols-2 gap-2">
-            <button
-              id="inspect-button"
-              class="bg-gray-700 hover:bg-gray-600 rounded p-2 text-sm transition-colors"
-            >
-              🔍 주변
-            </button>
-            <button
-              id="toggle-map-button"
-              class="bg-gray-700 hover:bg-gray-600 rounded p-2 text-sm transition-colors"
-            >
-              🗺️ 지도
-            </button>
-            <button
-              id="attack-button"
-              class="bg-game-danger hover:bg-red-600 rounded p-2 text-sm transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
-              disabled
-            >
-              ⚔️ 공격
-            </button>
-            <button
-              id="inventory-button"
-              class="bg-gray-700 hover:bg-gray-600 rounded p-2 text-sm transition-colors"
-            >
-              🎒 인벤토리
-            </button>
-          </div>
-        </div>
-      </div>
-
-      <!-- Center Panel - Main Game Area -->
-      <div class="flex-1 flex flex-col">
-        <!-- Top Bar -->
-        <div class="bg-black/40 backdrop-blur-sm border-b border-gray-700 p-4">
-          <div
-            class="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between"
+        <div
+          class="absolute inset-0 bg-gradient-to-br from-white/5 via-transparent to-game-accent/15 pointer-events-none"
+        ></div>
+        <div class="relative z-10 flex flex-col h-full">
+          <header
+            class="px-6 py-3 bg-black/40 border-b border-gray-800 flex items-center justify-between gap-4"
           >
-            <h1 class="text-2xl font-bold text-game-accent">환상의 세계 MUD</h1>
-            <div class="flex gap-2 sm:justify-end">
+            <div>
+              <h1
+                class="text-2xl font-extrabold tracking-wide text-game-accent"
+              >
+                환상의 세계 MUD
+              </h1>
+              <p class="text-xs text-gray-400 mt-1">
+                실시간 텍스트 MMORPG 어드벤처에 오신 것을 환영합니다
+              </p>
+            </div>
+            <div class="flex items-center gap-2">
               <button
                 id="settings-button"
-                class="bg-gray-700 hover:bg-gray-600 rounded p-2 transition-colors"
+                class="bg-gray-700/70 hover:bg-gray-600 rounded-full p-3 transition-colors"
+                aria-label="설정 열기"
               >
-                ⚙️ 설정
+                ⚙️
               </button>
               <button
                 id="help-button"
-                class="bg-gray-700 hover:bg-gray-600 rounded p-2 transition-colors"
+                class="bg-gray-700/70 hover:bg-gray-600 rounded-full p-3 transition-colors"
+                aria-label="도움말 열기"
               >
-                ❓ 도움말
+                ❓
               </button>
             </div>
-          </div>
-        </div>
+          </header>
 
-        <!-- Intro Section -->
-        <div
-          class="bg-black/40 backdrop-blur-sm border-b border-gray-700 p-4 text-sm md:text-base leading-relaxed"
-        >
-          <p class="text-gray-300">
-            환영합니다, 모험가! 이 텍스트 기반 RPG에서 다양한 장소를 탐험하고
-            몬스터와 싸워보세요. 아래 로그는 세계에서 벌어지는 일을 보여주며,
-            오른쪽 패널의 버튼으로 캐릭터를 조작할 수 있습니다.
-          </p>
-        </div>
+          <section class="px-6 pt-4 pb-3">
+            <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
+              <div
+                class="bg-black/45 border border-gray-700 rounded-2xl p-4 flex flex-col gap-4"
+              >
+                <div class="flex items-center justify-between">
+                  <div>
+                    <div class="text-xs uppercase tracking-wider text-gray-400">
+                      레벨
+                    </div>
+                    <div class="text-2xl font-extrabold text-white">
+                      Lv. <span id="player-level">1</span>
+                    </div>
+                  </div>
+                  <div class="text-right">
+                    <div class="text-xs uppercase tracking-wider text-gray-400">
+                      골드
+                    </div>
+                    <div
+                      id="player-gold"
+                      class="text-game-warning font-bold text-xl"
+                    >
+                      0
+                    </div>
+                  </div>
+                </div>
+                <div class="space-y-3">
+                  <div>
+                    <div
+                      class="flex items-center justify-between text-xs text-gray-300"
+                    >
+                      <span>체력</span>
+                      <span id="player-hp" class="font-semibold text-white"
+                        >100/100</span
+                      >
+                    </div>
+                    <div
+                      class="mt-1 h-2 bg-gray-700 rounded-full overflow-hidden"
+                    >
+                      <div
+                        id="player-hp-bar-main"
+                        class="h-2 bg-game-success rounded-full transition-all duration-300"
+                        style="width: 100%"
+                      ></div>
+                    </div>
+                  </div>
+                  <div>
+                    <div
+                      class="flex items-center justify-between text-xs text-gray-300"
+                    >
+                      <span>경험치</span>
+                      <span id="player-exp" class="font-semibold text-white"
+                        >0/100</span
+                      >
+                    </div>
+                    <div
+                      class="mt-1 h-2 bg-gray-700 rounded-full overflow-hidden"
+                    >
+                      <div
+                        id="player-exp-bar"
+                        class="h-2 bg-game-accent rounded-full transition-all duration-300"
+                        style="width: 0%"
+                      ></div>
+                    </div>
+                  </div>
+                </div>
+                <div class="flex flex-wrap gap-2 text-xs">
+                  <div class="bg-white/10 px-3 py-1 rounded-full font-semibold">
+                    ⚔️ 공격력
+                    <span id="player-attack" class="ml-1 text-white">10</span>
+                  </div>
+                  <div class="bg-white/10 px-3 py-1 rounded-full font-semibold">
+                    🛡️ 방어력
+                    <span id="player-defense" class="ml-1 text-white">5</span>
+                  </div>
+                </div>
+              </div>
+              <div
+                class="bg-black/45 border border-gray-700 rounded-2xl p-4 flex flex-col gap-3"
+              >
+                <div class="flex items-center justify-between">
+                  <h2
+                    class="text-sm font-semibold text-game-accent uppercase tracking-wider"
+                  >
+                    현재 위치
+                  </h2>
+                  <span class="text-xs text-gray-400">월드 정보</span>
+                </div>
+                <div class="bg-black/40 border border-gray-700 rounded-xl p-3">
+                  <div
+                    id="current-room-name"
+                    class="text-xl font-bold text-white"
+                  >
+                    시작의 마을
+                  </div>
+                  <div
+                    class="mt-3 grid grid-cols-2 gap-3 text-xs text-gray-300"
+                  >
+                    <div>
+                      <div
+                        class="text-[0.65rem] uppercase tracking-widest text-gray-400"
+                      >
+                        출구
+                      </div>
+                      <div id="available-exits" class="mt-1 text-sm text-white">
+                        북, 남, 서, 동
+                      </div>
+                    </div>
+                    <div>
+                      <div
+                        class="text-[0.65rem] uppercase tracking-widest text-gray-400"
+                      >
+                        몬스터
+                      </div>
+                      <div id="room-monsters" class="mt-1 text-sm text-white">
+                        없음
+                      </div>
+                    </div>
+                    <div>
+                      <div
+                        class="text-[0.65rem] uppercase tracking-widest text-gray-400"
+                      >
+                        NPC
+                      </div>
+                      <div id="room-npcs" class="mt-1 text-sm text-white">
+                        없음
+                      </div>
+                    </div>
+                    <div>
+                      <div
+                        class="text-[0.65rem] uppercase tracking-widest text-gray-400"
+                      >
+                        아이템
+                      </div>
+                      <div id="room-items" class="mt-1 text-sm text-white">
+                        없음
+                      </div>
+                    </div>
+                  </div>
+                </div>
+                <div
+                  id="mini-map"
+                  class="bg-black/35 border border-gray-700 rounded-xl p-3 flex items-center gap-3"
+                >
+                  <div class="flex-1">
+                    <div
+                      class="text-xs text-gray-400 uppercase tracking-widest"
+                    >
+                      미니맵
+                    </div>
+                    <div class="map-placeholder text-sm text-gray-500">
+                      탐험을 시작하세요
+                    </div>
+                  </div>
+                  <button
+                    id="toggle-map-button"
+                    class="shrink-0 bg-gray-700/80 hover:bg-gray-600 rounded-xl px-3 py-2 text-sm font-medium transition-colors whitespace-nowrap"
+                  >
+                    🗺️ 전체 지도
+                  </button>
+                </div>
+              </div>
+            </div>
+          </section>
 
-        <!-- Main Content Area -->
-        <div class="flex-1 flex flex-col md:flex-row p-4 gap-4">
-          <!-- Game Log -->
-          <div class="flex-1">
+          <section class="px-6 flex-1 pb-3">
             <div
-              class="bg-black/40 rounded-lg border border-gray-600 h-full min-h-[320px] flex flex-col"
+              class="bg-black/45 border border-gray-700 rounded-2xl h-full flex flex-col overflow-hidden"
             >
               <div
-                class="flex justify-between items-center p-4 border-b border-gray-600"
+                class="flex items-center justify-between border-b border-gray-700 px-5 py-3"
               >
                 <h3 class="text-lg font-bold text-game-accent">게임 로그</h3>
                 <button
                   id="clear-log"
-                  class="bg-gray-700 hover:bg-gray-600 rounded p-2 transition-colors"
+                  class="bg-gray-700/70 hover:bg-gray-600 rounded-full px-4 py-2 text-sm transition-colors"
                 >
-                  🗑️ 지우기
+                  🗑️ 로그 지우기
                 </button>
               </div>
               <div
                 id="log-window"
-                class="flex-1 p-4 overflow-y-auto space-y-2 text-sm"
+                class="flex-1 px-5 py-4 overflow-y-auto space-y-2 text-sm"
               >
                 <div class="text-gray-400">게임이 시작되었습니다...</div>
               </div>
             </div>
-          </div>
+          </section>
 
-          <!-- Right Panel - Movement & Items -->
-          <div
-            class="w-full md:w-80 bg-game-card/80 backdrop-blur-sm border-t md:border-t-0 md:border-l border-gray-700 p-4 space-y-4 md:h-auto md:overflow-y-auto"
-          >
-            <!-- Movement Controls -->
-            <div class="bg-black/40 rounded-lg p-4 border border-gray-600">
-              <h3 class="text-lg font-bold text-game-accent mb-3">이동</h3>
-              <div class="grid grid-cols-2 gap-2">
-                <button
-                  class="btn-direction bg-gray-700 hover:bg-gray-600 rounded p-3 transition-colors"
-                  data-dir="북"
+          <section class="px-6 pb-5">
+            <div class="grid grid-cols-1 md:grid-cols-[1.05fr_0.95fr] gap-3.5">
+              <div
+                class="bg-black/45 border border-gray-700 rounded-2xl p-4 flex flex-col"
+              >
+                <h3
+                  class="text-sm font-semibold text-game-accent uppercase tracking-widest mb-3"
                 >
-                  <div class="text-center">
-                    <div class="text-2xl">⬆️</div>
-                    <div class="text-sm">북</div>
-                  </div>
-                </button>
-                <button
-                  class="btn-direction bg-gray-700 hover:bg-gray-600 rounded p-3 transition-colors"
-                  data-dir="남"
+                  빠른 명령
+                </h3>
+                <div class="grid grid-cols-3 gap-2">
+                  <button
+                    id="inspect-button"
+                    class="bg-gray-700/80 hover:bg-gray-600 rounded-xl py-2 text-sm font-medium transition-colors"
+                  >
+                    🔍 주변
+                  </button>
+                  <button
+                    id="interaction-button"
+                    class="bg-gray-700/80 hover:bg-gray-600 rounded-xl py-2 text-sm font-medium transition-colors"
+                  >
+                    🤝 상호작용
+                  </button>
+                  <button
+                    id="inventory-button"
+                    class="bg-gray-700/80 hover:bg-gray-600 rounded-xl py-2 text-sm font-medium transition-colors"
+                  >
+                    🎒 인벤토리
+                  </button>
+                  <button
+                    id="attack-button"
+                    class="col-span-3 bg-game-danger hover:bg-red-600 rounded-xl py-2 text-sm font-semibold transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+                    disabled
+                  >
+                    ⚔️ 공격
+                  </button>
+                </div>
+              </div>
+              <div
+                class="bg-black/45 border border-gray-700 rounded-2xl p-4 flex flex-col gap-3"
+              >
+                <h3
+                  class="text-sm font-semibold text-game-accent uppercase tracking-widest"
                 >
-                  <div class="text-center">
-                    <div class="text-2xl">⬇️</div>
-                    <div class="text-sm">남</div>
+                  이동
+                </h3>
+                <div class="grid grid-cols-3 grid-rows-3 gap-2">
+                  <div></div>
+                  <button
+                    class="btn-direction bg-gray-700/80 hover:bg-gray-600 rounded-xl py-2.5 transition-colors flex flex-col items-center justify-center"
+                    data-dir="북"
+                  >
+                    <span class="text-2xl">⬆️</span>
+                    <span class="text-xs mt-1">북</span>
+                  </button>
+                  <div></div>
+                  <button
+                    class="btn-direction bg-gray-700/80 hover:bg-gray-600 rounded-xl py-2.5 transition-colors flex flex-col items-center justify-center"
+                    data-dir="서"
+                  >
+                    <span class="text-2xl">⬅️</span>
+                    <span class="text-xs mt-1">서</span>
+                  </button>
+                  <div
+                    class="flex items-center justify-center text-xs text-gray-500"
+                  >
+                    <div
+                      class="w-12 h-12 rounded-full border border-gray-600 flex items-center justify-center"
+                    >
+                      방향
+                    </div>
                   </div>
-                </button>
-                <button
-                  class="btn-direction bg-gray-700 hover:bg-gray-600 rounded p-3 transition-colors"
-                  data-dir="서"
-                >
-                  <div class="text-center">
-                    <div class="text-2xl">⬅️</div>
-                    <div class="text-sm">서</div>
-                  </div>
-                </button>
-                <button
-                  class="btn-direction bg-gray-700 hover:bg-gray-600 rounded p-3 transition-colors"
-                  data-dir="동"
-                >
-                  <div class="text-center">
-                    <div class="text-2xl">➡️</div>
-                    <div class="text-sm">동</div>
-                  </div>
-                </button>
+                  <button
+                    class="btn-direction bg-gray-700/80 hover:bg-gray-600 rounded-xl py-2.5 transition-colors flex flex-col items-center justify-center"
+                    data-dir="동"
+                  >
+                    <span class="text-2xl">➡️</span>
+                    <span class="text-xs mt-1">동</span>
+                  </button>
+                  <div></div>
+                  <button
+                    class="btn-direction bg-gray-700/80 hover:bg-gray-600 rounded-xl py-2.5 transition-colors flex flex-col items-center justify-center"
+                    data-dir="남"
+                  >
+                    <span class="text-2xl">⬇️</span>
+                    <span class="text-xs mt-1">남</span>
+                  </button>
+                  <div></div>
+                </div>
               </div>
             </div>
-
-            <!-- Room Items -->
-            <div class="bg-black/40 rounded-lg p-4 border border-gray-600">
-              <h3 class="text-lg font-bold text-game-accent mb-3">방 아이템</h3>
-              <div id="item-buttons" class="space-y-2">
-                <div class="text-gray-400 text-sm">아이템이 없습니다</div>
-              </div>
-            </div>
-
-            <!-- Inventory -->
-            <div class="bg-black/40 rounded-lg p-4 border border-gray-600">
-              <h3 class="text-lg font-bold text-game-accent mb-3">인벤토리</h3>
-              <div id="inventory-buttons" class="space-y-2">
-                <div class="text-gray-400 text-sm">비어있습니다</div>
-              </div>
-            </div>
-          </div>
+          </section>
         </div>
       </div>
     </div>
@@ -357,13 +450,67 @@
       </div>
     </div>
 
+    <!-- Interaction Modal -->
+    <div
+      id="interaction-modal"
+      class="fixed inset-0 bg-black/80 backdrop-blur-sm hidden items-center justify-center z-50"
+    >
+      <div
+        class="bg-game-card border border-gray-600 rounded-2xl p-6 w-11/12 max-w-md space-y-5"
+      >
+        <div class="flex justify-between items-center">
+          <h3 class="text-xl font-bold text-game-accent">상호작용</h3>
+          <button
+            id="close-interaction"
+            class="bg-gray-700 hover:bg-gray-600 rounded p-2 transition-colors"
+          >
+            ✕
+          </button>
+        </div>
+        <div class="space-y-4 text-sm">
+          <div>
+            <h4 class="text-gray-200 font-semibold mb-2">획득 가능한 아이템</h4>
+            <div
+              id="item-buttons"
+              class="space-y-2 max-h-48 overflow-y-auto pr-1"
+            >
+              <div class="text-gray-400 text-sm">아이템이 없습니다</div>
+            </div>
+          </div>
+          <div
+            class="bg-black/40 border border-gray-600 rounded-xl p-4 space-y-3"
+          >
+            <p class="text-sm font-semibold text-white">주요 환경 정보</p>
+            <div class="grid grid-cols-2 gap-3 text-xs text-gray-300">
+              <div>
+                <div class="text-gray-400">출구</div>
+                <div id="modal-exits" class="text-white text-sm">-</div>
+              </div>
+              <div>
+                <div class="text-gray-400">NPC</div>
+                <div id="modal-npcs" class="text-white text-sm">-</div>
+              </div>
+              <div>
+                <div class="text-gray-400">몬스터</div>
+                <div id="modal-monsters" class="text-white text-sm">-</div>
+              </div>
+              <div>
+                <div class="text-gray-400">아이템</div>
+                <div id="modal-items" class="text-white text-sm">-</div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+
     <!-- Inventory Modal -->
     <div
       id="inventory-modal"
       class="fixed inset-0 bg-black/80 backdrop-blur-sm hidden items-center justify-center z-50"
     >
       <div
-        class="bg-game-card border border-gray-600 rounded-lg p-6 w-11/12 max-w-md"
+        class="bg-game-card border border-gray-600 rounded-2xl p-6 w-11/12 max-w-md"
       >
         <div class="flex justify-between items-center mb-4">
           <h3 class="text-xl font-bold text-game-accent">인벤토리</h3>
@@ -374,7 +521,10 @@
             ✕
           </button>
         </div>
-        <div id="inventory-content" class="space-y-2">
+        <div
+          id="inventory-buttons"
+          class="space-y-2 max-h-64 overflow-y-auto pr-1 text-sm"
+        >
           <div class="text-gray-400 text-center py-4">
             인벤토리가 비어있습니다
           </div>
@@ -441,8 +591,8 @@
         </div>
         <div class="space-y-3 text-sm">
           <div>
-            <strong class="text-game-accent">이동:</strong> 방향 버튼 또는 WASD
-            키
+            <strong class="text-game-accent">이동:</strong> 방향 패드 또는 WASD/
+            화살표 키
           </div>
           <div>
             <strong class="text-game-accent">공격:</strong> 스페이스바 또는 공격
@@ -452,11 +602,16 @@
             <strong class="text-game-accent">주변 탐색:</strong> 주변 버튼
           </div>
           <div>
-            <strong class="text-game-accent">지도:</strong> 지도 버튼 또는 M 키
+            <strong class="text-game-accent">지도:</strong> 미니맵의 전체 지도
+            버튼 또는 M 키
           </div>
           <div>
             <strong class="text-game-accent">인벤토리:</strong> 인벤토리 버튼
             또는 I 키
+          </div>
+          <div>
+            <strong class="text-game-accent">상호작용:</strong> 상호작용 버튼
+            또는 E 키
           </div>
         </div>
       </div>

--- a/main.js
+++ b/main.js
@@ -1,7 +1,14 @@
-import { initUI, logMessage, updateStatus, updateNavigation, updateCombatUI, updateMapDisplay } from './uiManager.js';
-import { parseCommand } from './commandParser.js';
-import { gameState, initGame } from './player.js';
-import { getCurrentRoom, getMapGrid } from './mapManager.js';
+import {
+  initUI,
+  logMessage,
+  updateStatus,
+  updateNavigation,
+  updateCombatUI,
+  updateMapDisplay,
+} from "./uiManager.js";
+import { parseCommand } from "./commandParser.js";
+import { gameState, initGame } from "./player.js";
+import { getCurrentRoom, getMapGrid } from "./mapManager.js";
 
 // Global state for UI interactions
 let isMapVisible = false;
@@ -9,422 +16,515 @@ let isCombatModalVisible = false;
 let isInventoryModalVisible = false;
 let isSettingsModalVisible = false;
 let isHelpModalVisible = false;
+let isInteractionModalVisible = false;
 
 function setupEventListeners() {
-    // Movement buttons
-    document.querySelectorAll('.btn-direction').forEach(btn => {
-        btn.addEventListener('click', () => {
-            const dir = btn.getAttribute('data-dir');
-            logMessage(`> 이동 ${dir}`);
-            parseCommand(`이동 ${dir}`);
-            updateUI();
-            addRecentAction(`이동: ${dir}`);
-        });
+  // Movement buttons
+  document.querySelectorAll(".btn-direction").forEach((btn) => {
+    btn.addEventListener("click", () => {
+      const dir = btn.getAttribute("data-dir");
+      logMessage(`> 이동 ${dir}`);
+      parseCommand(`이동 ${dir}`);
+      updateUI();
+      addRecentAction(`이동: ${dir}`);
     });
+  });
 
-    // Action buttons
-    document.getElementById('inspect-button').addEventListener('click', () => {
-        logMessage('> 주변');
-        parseCommand('주변');
-        updateUI();
-        addRecentAction('주변 탐색');
+  // Action buttons
+  document.getElementById("inspect-button").addEventListener("click", () => {
+    logMessage("> 주변");
+    parseCommand("주변");
+    updateUI();
+    addRecentAction("주변 탐색");
+  });
+
+  document.getElementById("toggle-map-button").addEventListener("click", () => {
+    toggleMap();
+  });
+
+  document.getElementById("attack-button").addEventListener("click", () => {
+    logMessage("> 공격");
+    parseCommand("공격");
+    updateUI();
+    addRecentAction("공격");
+  });
+
+  const interactionBtn = document.getElementById("interaction-button");
+  if (interactionBtn) {
+    interactionBtn.addEventListener("click", () => {
+      toggleInteraction();
     });
+  }
 
-    document.getElementById('toggle-map-button').addEventListener('click', () => {
-        toggleMap();
+  document.getElementById("inventory-button").addEventListener("click", () => {
+    toggleInventory();
+  });
+
+  document.getElementById("settings-button").addEventListener("click", () => {
+    toggleSettings();
+  });
+
+  document.getElementById("help-button").addEventListener("click", () => {
+    toggleHelp();
+  });
+
+  // Combat modal buttons
+  const modalAtkBtn = document.getElementById("combat-attack-button");
+  if (modalAtkBtn) {
+    modalAtkBtn.addEventListener("click", () => {
+      logMessage("> 공격");
+      parseCommand("공격");
+      updateUI();
+      addRecentAction("전투 공격");
     });
+  }
 
-    document.getElementById('attack-button').addEventListener('click', () => {
-        logMessage('> 공격');
-        parseCommand('공격');
-        updateUI();
-        addRecentAction('공격');
+  const fleeBtn = document.getElementById("combat-flee-button");
+  if (fleeBtn) {
+    fleeBtn.addEventListener("click", () => {
+      logMessage("> 도망");
+      parseCommand("도망");
+      updateUI();
+      addRecentAction("도망");
+      closeCombatModal();
     });
+  }
 
-    document.getElementById('inventory-button').addEventListener('click', () => {
-        toggleInventory();
+  // Modal close buttons
+  const closeCombatBtn = document.getElementById("close-combat");
+  if (closeCombatBtn) {
+    closeCombatBtn.addEventListener("click", () => {
+      closeCombatModal();
     });
+  }
 
-    document.getElementById('settings-button').addEventListener('click', () => {
-        toggleSettings();
+  const closeMapBtn = document.getElementById("close-map");
+  if (closeMapBtn) {
+    closeMapBtn.addEventListener("click", () => {
+      closeMap();
     });
+  }
 
-    document.getElementById('help-button').addEventListener('click', () => {
-        toggleHelp();
+  const closeInventoryBtn = document.getElementById("close-inventory");
+  if (closeInventoryBtn) {
+    closeInventoryBtn.addEventListener("click", () => {
+      closeInventory();
     });
+  }
 
-    // Combat modal buttons
-    const modalAtkBtn = document.getElementById('combat-attack-button');
-    if (modalAtkBtn) {
-        modalAtkBtn.addEventListener('click', () => {
-            logMessage('> 공격');
-            parseCommand('공격');
-            updateUI();
-            addRecentAction('전투 공격');
-        });
-    }
+  const closeInteractionBtn = document.getElementById("close-interaction");
+  if (closeInteractionBtn) {
+    closeInteractionBtn.addEventListener("click", () => {
+      closeInteraction();
+    });
+  }
 
-    const fleeBtn = document.getElementById('combat-flee-button');
-    if (fleeBtn) {
-        fleeBtn.addEventListener('click', () => {
-            logMessage('> 도망');
-            parseCommand('도망');
-            updateUI();
-            addRecentAction('도망');
-            closeCombatModal();
-        });
-    }
+  const closeSettingsBtn = document.getElementById("close-settings");
+  if (closeSettingsBtn) {
+    closeSettingsBtn.addEventListener("click", () => {
+      closeSettings();
+    });
+  }
 
-    // Modal close buttons
-    const closeCombatBtn = document.getElementById('close-combat');
-    if (closeCombatBtn) {
-        closeCombatBtn.addEventListener('click', () => {
-            closeCombatModal();
-        });
-    }
+  const closeHelpBtn = document.getElementById("close-help");
+  if (closeHelpBtn) {
+    closeHelpBtn.addEventListener("click", () => {
+      closeHelp();
+    });
+  }
 
-    const closeMapBtn = document.getElementById('close-map');
-    if (closeMapBtn) {
-        closeMapBtn.addEventListener('click', () => {
-            closeMap();
-        });
-    }
+  // Clear log button
+  const clearLogBtn = document.getElementById("clear-log");
+  if (clearLogBtn) {
+    clearLogBtn.addEventListener("click", () => {
+      clearLog();
+    });
+  }
 
-    const closeInventoryBtn = document.getElementById('close-inventory');
-    if (closeInventoryBtn) {
-        closeInventoryBtn.addEventListener('click', () => {
-            closeInventory();
-        });
-    }
+  // Keyboard shortcuts
+  document.addEventListener("keydown", (e) => {
+    if (e.target.tagName === "INPUT" || e.target.tagName === "TEXTAREA") return;
 
-    const closeSettingsBtn = document.getElementById('close-settings');
-    if (closeSettingsBtn) {
-        closeSettingsBtn.addEventListener('click', () => {
-            closeSettings();
-        });
-    }
-
-    const closeHelpBtn = document.getElementById('close-help');
-    if (closeHelpBtn) {
-        closeHelpBtn.addEventListener('click', () => {
-            closeHelp();
-        });
-    }
-
-    // Clear log button
-    const clearLogBtn = document.getElementById('clear-log');
-    if (clearLogBtn) {
-        clearLogBtn.addEventListener('click', () => {
-            clearLog();
-        });
-    }
-
-    // Keyboard shortcuts
-    document.addEventListener('keydown', (e) => {
-        if (e.target.tagName === 'INPUT' || e.target.tagName === 'TEXTAREA') return;
-        
-        switch(e.key) {
-            case 'ArrowUp':
-            case 'w':
-            case 'W':
-                e.preventDefault();
-                simulateButtonClick('북');
-                break;
-            case 'ArrowDown':
-            case 's':
-            case 'S':
-                e.preventDefault();
-                simulateButtonClick('남');
-                break;
-            case 'ArrowLeft':
-            case 'a':
-            case 'A':
-                e.preventDefault();
-                simulateButtonClick('서');
-                break;
-            case 'ArrowRight':
-            case 'd':
-            case 'D':
-                e.preventDefault();
-                simulateButtonClick('동');
-                break;
-            case ' ':
-                e.preventDefault();
-                if (document.getElementById('attack-button').disabled === false) {
-                    simulateButtonClick('공격');
-                }
-                break;
-            case 'm':
-            case 'M':
-                e.preventDefault();
-                toggleMap();
-                break;
-            case 'i':
-            case 'I':
-                e.preventDefault();
-                toggleInventory();
-                break;
-            case 'Escape':
-                e.preventDefault();
-                if (isMapVisible) closeMap();
-                if (isCombatModalVisible) closeCombatModal();
-                if (isInventoryModalVisible) closeInventory();
-                if (isSettingsModalVisible) closeSettings();
-                if (isHelpModalVisible) closeHelp();
-                break;
+    switch (e.key) {
+      case "ArrowUp":
+      case "w":
+      case "W":
+        e.preventDefault();
+        simulateButtonClick("북");
+        break;
+      case "ArrowDown":
+      case "s":
+      case "S":
+        e.preventDefault();
+        simulateButtonClick("남");
+        break;
+      case "ArrowLeft":
+      case "a":
+      case "A":
+        e.preventDefault();
+        simulateButtonClick("서");
+        break;
+      case "ArrowRight":
+      case "d":
+      case "D":
+        e.preventDefault();
+        simulateButtonClick("동");
+        break;
+      case " ":
+        e.preventDefault();
+        if (document.getElementById("attack-button").disabled === false) {
+          simulateButtonClick("공격");
         }
-    });
+        break;
+      case "m":
+      case "M":
+        e.preventDefault();
+        toggleMap();
+        break;
+      case "i":
+      case "I":
+        e.preventDefault();
+        toggleInventory();
+        break;
+      case "e":
+      case "E":
+        e.preventDefault();
+        toggleInteraction();
+        break;
+      case "Escape":
+        e.preventDefault();
+        if (isMapVisible) closeMap();
+        if (isCombatModalVisible) closeCombatModal();
+        if (isInventoryModalVisible) closeInventory();
+        if (isInteractionModalVisible) closeInteraction();
+        if (isSettingsModalVisible) closeSettings();
+        if (isHelpModalVisible) closeHelp();
+        break;
+    }
+  });
 }
 
 function simulateButtonClick(action) {
-    if (action === '공격') {
-        const attackBtn = document.getElementById('attack-button');
-        if (!attackBtn.disabled) {
-            attackBtn.click();
-        }
-    } else {
-        const moveBtn = document.querySelector(`[data-dir="${action}"]`);
-        if (moveBtn) {
-            moveBtn.click();
-        }
+  if (action === "공격") {
+    const attackBtn = document.getElementById("attack-button");
+    if (!attackBtn.disabled) {
+      attackBtn.click();
     }
+  } else {
+    const moveBtn = document.querySelector(`[data-dir="${action}"]`);
+    if (moveBtn) {
+      moveBtn.click();
+    }
+  }
 }
 
 function toggleMap() {
-    if (isMapVisible) {
-        closeMap();
-    } else {
-        openMap();
-    }
+  if (isMapVisible) {
+    closeMap();
+  } else {
+    openMap();
+  }
 }
 
 function openMap() {
-    const mapDisplay = document.getElementById('map-display');
-    mapDisplay.classList.remove('hidden');
-    mapDisplay.classList.add('flex');
-    isMapVisible = true;
-    updateMapDisplay(getMapGrid());
-    addRecentAction('지도 열기');
+  const mapDisplay = document.getElementById("map-display");
+  mapDisplay.classList.remove("hidden");
+  mapDisplay.classList.add("flex");
+  isMapVisible = true;
+  updateMapDisplay(getMapGrid());
+  addRecentAction("지도 열기");
 }
 
 function closeMap() {
-    const mapDisplay = document.getElementById('map-display');
-    mapDisplay.classList.add('hidden');
-    mapDisplay.classList.remove('flex');
-    isMapVisible = false;
+  const mapDisplay = document.getElementById("map-display");
+  mapDisplay.classList.add("hidden");
+  mapDisplay.classList.remove("flex");
+  isMapVisible = false;
 }
 
 function toggleInventory() {
-    if (isInventoryModalVisible) {
-        closeInventory();
-    } else {
-        openInventory();
-    }
+  if (isInventoryModalVisible) {
+    closeInventory();
+  } else {
+    openInventory();
+  }
 }
 
 function openInventory() {
-    const inventoryModal = document.getElementById('inventory-modal');
-    inventoryModal.classList.remove('hidden');
-    inventoryModal.classList.add('flex');
-    isInventoryModalVisible = true;
-    updateInventoryDisplay();
-    addRecentAction('인벤토리 열기');
+  const inventoryModal = document.getElementById("inventory-modal");
+  inventoryModal.classList.remove("hidden");
+  inventoryModal.classList.add("flex");
+  isInventoryModalVisible = true;
+  updateInventoryDisplay();
+  addRecentAction("인벤토리 열기");
 }
 
 function closeInventory() {
-    const inventoryModal = document.getElementById('inventory-modal');
-    inventoryModal.classList.add('hidden');
-    inventoryModal.classList.remove('flex');
-    isInventoryModalVisible = false;
+  const inventoryModal = document.getElementById("inventory-modal");
+  inventoryModal.classList.add("hidden");
+  inventoryModal.classList.remove("flex");
+  isInventoryModalVisible = false;
+}
+
+function toggleInteraction() {
+  if (isInteractionModalVisible) {
+    closeInteraction();
+  } else {
+    openInteraction();
+  }
+}
+
+function openInteraction() {
+  const interactionModal = document.getElementById("interaction-modal");
+  if (!interactionModal) return;
+  interactionModal.classList.remove("hidden");
+  interactionModal.classList.add("flex");
+  isInteractionModalVisible = true;
+  bindDynamicButtons();
+  addRecentAction("상호작용 열기");
+}
+
+function closeInteraction() {
+  const interactionModal = document.getElementById("interaction-modal");
+  if (!interactionModal) return;
+  interactionModal.classList.add("hidden");
+  interactionModal.classList.remove("flex");
+  isInteractionModalVisible = false;
 }
 
 function toggleSettings() {
-    if (isSettingsModalVisible) {
-        closeSettings();
-    } else {
-        openSettings();
-    }
+  if (isSettingsModalVisible) {
+    closeSettings();
+  } else {
+    openSettings();
+  }
 }
 
 function openSettings() {
-    const settingsModal = document.getElementById('settings-modal');
-    settingsModal.classList.remove('hidden');
-    settingsModal.classList.add('flex');
-    isSettingsModalVisible = true;
-    addRecentAction('설정 열기');
+  const settingsModal = document.getElementById("settings-modal");
+  settingsModal.classList.remove("hidden");
+  settingsModal.classList.add("flex");
+  isSettingsModalVisible = true;
+  addRecentAction("설정 열기");
 }
 
 function closeSettings() {
-    const settingsModal = document.getElementById('settings-modal');
-    settingsModal.classList.add('hidden');
-    settingsModal.classList.remove('flex');
-    isSettingsModalVisible = false;
+  const settingsModal = document.getElementById("settings-modal");
+  settingsModal.classList.add("hidden");
+  settingsModal.classList.remove("flex");
+  isSettingsModalVisible = false;
 }
 
 function toggleHelp() {
-    if (isHelpModalVisible) {
-        closeHelp();
-    } else {
-        openHelp();
-    }
+  if (isHelpModalVisible) {
+    closeHelp();
+  } else {
+    openHelp();
+  }
 }
 
 function openHelp() {
-    const helpModal = document.getElementById('help-modal');
-    helpModal.classList.remove('hidden');
-    helpModal.classList.add('flex');
-    isHelpModalVisible = true;
-    addRecentAction('도움말 열기');
+  const helpModal = document.getElementById("help-modal");
+  helpModal.classList.remove("hidden");
+  helpModal.classList.add("flex");
+  isHelpModalVisible = true;
+  addRecentAction("도움말 열기");
 }
 
 function closeHelp() {
-    const helpModal = document.getElementById('help-modal');
-    helpModal.classList.add('hidden');
-    helpModal.classList.remove('flex');
-    isHelpModalVisible = false;
+  const helpModal = document.getElementById("help-modal");
+  helpModal.classList.add("hidden");
+  helpModal.classList.remove("flex");
+  isHelpModalVisible = false;
 }
 
 function closeCombatModal() {
-    const combatModal = document.getElementById('combat-modal');
-    combatModal.classList.add('hidden');
-    combatModal.classList.remove('flex');
-    isCombatModalVisible = false;
+  const combatModal = document.getElementById("combat-modal");
+  combatModal.classList.add("hidden");
+  combatModal.classList.remove("flex");
+  isCombatModalVisible = false;
 }
 
 function clearLog() {
-    const logWindow = document.getElementById('log-window');
-    logWindow.innerHTML = '<div class="text-gray-400">로그가 지워졌습니다...</div>';
-    addRecentAction('로그 지우기');
+  const logWindow = document.getElementById("log-window");
+  logWindow.innerHTML =
+    '<div class="text-gray-400">로그가 지워졌습니다...</div>';
+  addRecentAction("로그 지우기");
 }
 
 function updateInventoryDisplay() {
-    const inventoryContent = document.getElementById('inventory-content');
-    // This would be populated with actual inventory data
-    inventoryContent.innerHTML = '<div class="text-gray-400 text-center py-4">인벤토리가 비어있습니다</div>';
+  renderInventoryButtons();
 }
 
 function addRecentAction(action) {
-    // This function can be used to track recent actions if needed
-    console.log(`Action: ${action}`);
+  // This function can be used to track recent actions if needed
+  console.log(`Action: ${action}`);
 }
 
 function bindDynamicButtons() {
-    // Item buttons
-    const itemContainer = document.getElementById('item-buttons');
-    itemContainer.innerHTML = '';
-    const room = getCurrentRoom();
-    
-    if (room.items.length === 0) {
-        const noItems = document.createElement('div');
-        noItems.className = 'text-gray-400 text-sm';
-        noItems.textContent = '아이템이 없습니다';
-        itemContainer.appendChild(noItems);
-    } else {
-        room.items.forEach(item => {
-            const btn = document.createElement('button');
-            btn.className = 'w-full bg-gray-700 hover:bg-gray-600 rounded p-2 text-sm transition-colors text-left';
-            btn.innerHTML = `
-                <span class="mr-2">📦</span>
-                <span>줍기 ${item.name}</span>
-            `;
-            btn.addEventListener('click', () => {
-                logMessage(`> 줍기 ${item.name}`);
-                parseCommand(`줍기 ${item.name}`);
-                updateUI();
-                addRecentAction(`줍기: ${item.name}`);
-            });
-            itemContainer.appendChild(btn);
-        });
-    }
+  renderRoomItemButtons();
+  renderInventoryButtons();
+}
 
-    // Inventory buttons
-    const invContainer = document.getElementById('inventory-buttons');
-    invContainer.innerHTML = '';
-    
-    if (gameState.inventory.length === 0) {
-        const noItems = document.createElement('div');
-        noItems.className = 'text-gray-400 text-sm';
-        noItems.textContent = '비어있습니다';
-        invContainer.appendChild(noItems);
-    } else {
-        gameState.inventory.forEach(item => {
-            const btn = document.createElement('button');
-            btn.className = 'w-full bg-gray-700 hover:bg-gray-600 rounded p-2 text-sm transition-colors text-left';
-            btn.innerHTML = `
-                <span class="mr-2">🎒</span>
-                <span>사용 ${item.name}</span>
-            `;
-            btn.addEventListener('click', () => {
-                logMessage(`> 사용 ${item.name}`);
-                parseCommand(`사용 ${item.name}`);
-                updateUI();
-                addRecentAction(`사용: ${item.name}`);
-            });
-            invContainer.appendChild(btn);
-        });
-    }
+function renderRoomItemButtons() {
+  const itemContainer = document.getElementById("item-buttons");
+  if (!itemContainer) return;
+
+  itemContainer.innerHTML = "";
+  const room = getCurrentRoom();
+
+  if (!room || !room.items || room.items.length === 0) {
+    const noItems = document.createElement("div");
+    noItems.className = "text-gray-400 text-sm";
+    noItems.textContent = "아이템이 없습니다";
+    itemContainer.appendChild(noItems);
+    return;
+  }
+
+  room.items.forEach((item) => {
+    const btn = document.createElement("button");
+    btn.className =
+      "w-full bg-gray-700/80 hover:bg-gray-600 rounded-lg p-2 text-sm transition-colors text-left flex items-center gap-2";
+    btn.innerHTML = `
+            <span>📦</span>
+            <span>줍기 ${item.name}</span>
+        `;
+    btn.addEventListener("click", () => {
+      logMessage(`> 줍기 ${item.name}`);
+      parseCommand(`줍기 ${item.name}`);
+      updateUI();
+      addRecentAction(`줍기: ${item.name}`);
+    });
+    itemContainer.appendChild(btn);
+  });
+}
+
+function renderInventoryButtons() {
+  const invContainer = document.getElementById("inventory-buttons");
+  if (!invContainer) return;
+
+  invContainer.innerHTML = "";
+
+  if (!gameState.inventory || gameState.inventory.length === 0) {
+    const noItems = document.createElement("div");
+    noItems.className = "text-gray-400 text-sm text-center py-4";
+    noItems.textContent = "인벤토리가 비어있습니다";
+    invContainer.appendChild(noItems);
+    return;
+  }
+
+  gameState.inventory.forEach((item) => {
+    const btn = document.createElement("button");
+    btn.className =
+      "w-full bg-gray-700/80 hover:bg-gray-600 rounded-lg p-2 text-sm transition-colors text-left flex items-center gap-2";
+    btn.innerHTML = `
+            <span>🎒</span>
+            <span>사용 ${item.name}</span>
+        `;
+    btn.addEventListener("click", () => {
+      logMessage(`> 사용 ${item.name}`);
+      parseCommand(`사용 ${item.name}`);
+      updateUI();
+      addRecentAction(`사용: ${item.name}`);
+    });
+    invContainer.appendChild(btn);
+  });
 }
 
 function updateUI() {
-    updateStatus(gameState);
-    const room = getCurrentRoom();
-    updateNavigation(room);
-    updateCombatUI(room);
-    updateMapDisplay(getMapGrid());
-    bindDynamicButtons();
-    
-    // Update all stats
-    updateAllStats();
+  updateStatus(gameState);
+  const room = getCurrentRoom();
+  updateNavigation(room);
+  updateCombatUI(room);
+  updateMapDisplay(getMapGrid());
+  bindDynamicButtons();
+
+  // Update all stats
+  updateAllStats();
 }
 
 function updateAllStats() {
-    // Update player stats
-    const attackEl = document.getElementById('player-attack');
-    const defenseEl = document.getElementById('player-defense');
-    const goldEl = document.getElementById('player-gold');
-    const hpEl = document.getElementById('player-hp');
-    const levelEl = document.getElementById('player-level');
-    const expEl = document.getElementById('player-exp');
-    
-    if (attackEl) attackEl.textContent = gameState.attack || 10;
-    if (defenseEl) defenseEl.textContent = gameState.defense || 5;
-    if (goldEl) goldEl.textContent = gameState.gold || 0;
-    if (hpEl) hpEl.textContent = `${gameState.hp || 100}/${gameState.maxHp || 100}`;
-    if (levelEl) levelEl.textContent = gameState.level || 1;
-    if (expEl) expEl.textContent = `${gameState.exp || 0}/${gameState.expToNext || 100}`;
-}
+  // Update player stats
+  const attackEl = document.getElementById("player-attack");
+  const defenseEl = document.getElementById("player-defense");
+  const goldEl = document.getElementById("player-gold");
+  const hpEl = document.getElementById("player-hp");
+  const levelEl = document.getElementById("player-level");
+  const expEl = document.getElementById("player-exp");
+
+  if (attackEl) attackEl.textContent = gameState.attack || 10;
+  if (defenseEl) defenseEl.textContent = gameState.defense || 5;
+  if (goldEl) goldEl.textContent = gameState.gold || 0;
+  if (hpEl)
+    hpEl.textContent = `${gameState.hp || 100}/${gameState.maxHp || 100}`;
+  if (levelEl) levelEl.textContent = gameState.level || 1;
+  if (expEl)
+    expEl.textContent = `${gameState.exp || 0}/${gameState.expToNext || 100}`;
+
+  const hpBarMain = document.getElementById("player-hp-bar-main");
+  const expBar = document.getElementById("player-exp-bar");
+
+  if (hpBarMain) {
+    const maxHp = gameState.maxHp || 100;
+    const currentHp = Math.max(0, Math.min(maxHp, gameState.hp || 0));
+    const hpPercent = maxHp > 0 ? (currentHp / maxHp) * 100 : 0;
+    const clampedPercent = Math.max(0, Math.min(100, hpPercent));
+
+    hpBarMain.style.width = `${clampedPercent}%`;
+    hpBarMain.classList.remove(
+      "bg-game-success",
+      "bg-game-warning",
+      "bg-game-danger",
+    );
+
+    if (clampedPercent > 60) {
+      hpBarMain.classList.add("bg-game-success");
+    } else if (clampedPercent > 30) {
+      hpBarMain.classList.add("bg-game-warning");
+    } else {
+      hpBarMain.classList.add("bg-game-danger");
+    }
+  }
+
+  if (expBar) {
+    const expToNext = gameState.expToNext || 100;
+    const currentExp = Math.max(0, Math.min(expToNext, gameState.exp || 0));
+    const expPercent = expToNext > 0 ? (currentExp / expToNext) * 100 : 0;
+    const clampedExpPercent = Math.max(0, Math.min(100, expPercent));
+    expBar.style.width = `${clampedExpPercent}%`;
+  }
 }
 
 function showLoading() {
-    const loadingOverlay = document.getElementById('loading-overlay');
-    if (loadingOverlay) {
-        loadingOverlay.classList.remove('hidden');
-        loadingOverlay.classList.add('flex');
-    }
+  const loadingOverlay = document.getElementById("loading-overlay");
+  if (loadingOverlay) {
+    loadingOverlay.classList.remove("hidden");
+    loadingOverlay.classList.add("flex");
+  }
 }
 
 function hideLoading() {
-    const loadingOverlay = document.getElementById('loading-overlay');
-    if (loadingOverlay) {
-        loadingOverlay.classList.add('hidden');
-        loadingOverlay.classList.remove('flex');
-    }
+  const loadingOverlay = document.getElementById("loading-overlay");
+  if (loadingOverlay) {
+    loadingOverlay.classList.add("hidden");
+    loadingOverlay.classList.remove("flex");
+  }
 }
 
 // Initialize game
-window.addEventListener('load', () => {
-    showLoading();
-    
-    // Simulate loading time for better UX
-    setTimeout(() => {
-        initGame();
-        initUI();
-        setupEventListeners();
-        updateUI();
-        logMessage('🎮 환상의 세계 MUD에 오신 것을 환영합니다!');
-        logMessage('💡 이동하려면 방향 버튼을 클릭하거나 WASD 키를 사용하세요.');
-        logMessage('⚔️ 전투가 시작되면 공격 버튼이 활성화됩니다.');
-        logMessage('🗺️ 지도 버튼으로 월드 맵을 확인할 수 있습니다.');
-        hideLoading();
-    }, 1000);
+window.addEventListener("load", () => {
+  showLoading();
+
+  // Simulate loading time for better UX
+  setTimeout(() => {
+    initGame();
+    initUI();
+    setupEventListeners();
+    updateUI();
+    logMessage("🎮 환상의 세계 MUD에 오신 것을 환영합니다!");
+    logMessage("💡 이동하려면 방향 버튼을 클릭하거나 WASD 키를 사용하세요.");
+    logMessage("⚔️ 전투가 시작되면 공격 버튼이 활성화됩니다.");
+    logMessage("🗺️ 지도 버튼으로 월드 맵을 확인할 수 있습니다.");
+    hideLoading();
+  }, 1000);
 });

--- a/uiManager.js
+++ b/uiManager.js
@@ -1,203 +1,218 @@
-import { gameState } from './player.js';
+import { gameState } from "./player.js";
 
 export function initUI() {
-    updateStatus();
+  updateStatus();
 }
 
 export function logMessage(msg) {
-    const log = document.getElementById('log-window');
-    const p = document.createElement('div');
-    p.textContent = msg;
-    p.className = 'text-sm mb-1';
-    log.appendChild(p);
-    log.scrollTop = log.scrollHeight;
+  const log = document.getElementById("log-window");
+  const p = document.createElement("div");
+  p.textContent = msg;
+  p.className = "text-sm mb-1";
+  log.appendChild(p);
+  log.scrollTop = log.scrollHeight;
 }
 
 export function updateStatus(state) {
-    if (!state) return;
-    
-    // Update main status display
-    const hpEl = document.getElementById('player-hp');
-    const levelEl = document.getElementById('player-level');
-    const expEl = document.getElementById('player-exp');
-    
-    if (hpEl) hpEl.textContent = `${state.hp}/${state.maxHp}`;
-    if (levelEl) levelEl.textContent = state.level || 1;
-    if (expEl) expEl.textContent = `${state.exp || 0}/${state.expToNext || 100}`;
-    
-    // Update sidebar stats
-    const attackEl = document.getElementById('player-attack');
-    const defenseEl = document.getElementById('player-defense');
-    const goldEl = document.getElementById('player-gold');
-    
-    if (attackEl) attackEl.textContent = state.attack || 10;
-    if (defenseEl) defenseEl.textContent = state.defense || 5;
-    if (goldEl) goldEl.textContent = state.gold || 0;
+  if (!state) return;
+
+  // Update main status display
+  const hpEl = document.getElementById("player-hp");
+  const levelEl = document.getElementById("player-level");
+  const expEl = document.getElementById("player-exp");
+
+  if (hpEl) hpEl.textContent = `${state.hp}/${state.maxHp}`;
+  if (levelEl) levelEl.textContent = state.level || 1;
+  if (expEl) expEl.textContent = `${state.exp || 0}/${state.expToNext || 100}`;
+
+  // Update sidebar stats
+  const attackEl = document.getElementById("player-attack");
+  const defenseEl = document.getElementById("player-defense");
+  const goldEl = document.getElementById("player-gold");
+
+  if (attackEl) attackEl.textContent = state.attack || 10;
+  if (defenseEl) defenseEl.textContent = state.defense || 5;
+  if (goldEl) goldEl.textContent = state.gold || 0;
 }
 
 export function updateNavigation(room) {
-    if (!room) return;
-    
-    // Update room title
-    const roomNameEl = document.getElementById('current-room-name');
-    if (roomNameEl) {
-        roomNameEl.textContent = room.name;
+  if (!room) return;
+
+  // Update room title
+  const roomNameEl = document.getElementById("current-room-name");
+  if (roomNameEl) {
+    roomNameEl.textContent = room.name;
+  }
+
+  // Update room details
+  const exitsEl = document.getElementById("available-exits");
+  const itemsEl = document.getElementById("room-items");
+  const npcsEl = document.getElementById("room-npcs");
+  const monstersEl = document.getElementById("room-monsters");
+  const modalExitsEl = document.getElementById("modal-exits");
+  const modalItemsEl = document.getElementById("modal-items");
+  const modalNpcsEl = document.getElementById("modal-npcs");
+  const modalMonstersEl = document.getElementById("modal-monsters");
+
+  if (exitsEl) {
+    const exitList =
+      Object.keys(room.exits).length > 0
+        ? Object.keys(room.exits).join(", ")
+        : "없음";
+    exitsEl.textContent = exitList;
+    if (modalExitsEl) {
+      modalExitsEl.textContent = exitList;
     }
-    
-    // Update room details
-    const exitsEl = document.getElementById('available-exits');
-    const itemsEl = document.getElementById('room-items');
-    const npcsEl = document.getElementById('room-npcs');
-    const monstersEl = document.getElementById('room-monsters');
-    
-    if (exitsEl) {
-        const exitList = Object.keys(room.exits).length > 0 
-            ? Object.keys(room.exits).join(', ')
-            : '없음';
-        exitsEl.textContent = exitList;
+  }
+
+  if (itemsEl) {
+    const itemList =
+      room.items.length > 0 ? room.items.map((i) => i.name).join(", ") : "없음";
+    itemsEl.textContent = itemList;
+    if (modalItemsEl) {
+      modalItemsEl.textContent = itemList;
     }
-    
-    if (itemsEl) {
-        const itemList = room.items.length > 0 
-            ? room.items.map(i => i.name).join(', ')
-            : '없음';
-        itemsEl.textContent = itemList;
+  }
+
+  if (npcsEl) {
+    const npcList =
+      room.npcs && room.npcs.length > 0 ? room.npcs.join(", ") : "없음";
+    npcsEl.textContent = npcList;
+    if (modalNpcsEl) {
+      modalNpcsEl.textContent = npcList;
     }
-    
-    if (npcsEl) {
-        const npcList = room.npcs && room.npcs.length > 0 
-            ? room.npcs.join(', ')
-            : '없음';
-        npcsEl.textContent = npcList;
+  }
+
+  if (monstersEl) {
+    const monsterList =
+      room.monsters && room.monsters.length > 0
+        ? room.monsters.map((m) => m.name).join(", ")
+        : "없음";
+    monstersEl.textContent = monsterList;
+    if (modalMonstersEl) {
+      modalMonstersEl.textContent = monsterList;
     }
-    
-    if (monstersEl) {
-        const monsterList = room.monsters && room.monsters.length > 0 
-            ? room.monsters.map(m => m.name).join(', ')
-            : '없음';
-        monstersEl.textContent = monsterList;
-    }
+  }
 }
 
 export function updateCombatUI(room) {
-    const attackBtn = document.getElementById('attack-button');
-    const combatModal = document.getElementById('combat-modal');
-    
-    if (room && room.monsters && room.monsters.length > 0) {
-        const monster = room.monsters[0];
-        
-        // Show combat modal
-        if (combatModal) {
-            combatModal.classList.remove('hidden');
-            combatModal.classList.add('flex');
-        }
-        
-        // Enable attack button
-        if (attackBtn) {
-            attackBtn.disabled = false;
-            attackBtn.classList.remove('opacity-50', 'cursor-not-allowed');
-        }
-        
-        // Update HP bars
-        updateHPBar('player-hp-bar', gameState.hp, gameState.maxHp);
-        updateHPBar('monster-hp-bar', monster.hp, monster.maxHp);
-        
-        // Update HP text
-        const playerHpText = document.getElementById('player-hp-bar-text');
-        const monsterHpText = document.getElementById('monster-hp-bar-text');
-        
-        if (playerHpText) {
-            playerHpText.textContent = `${gameState.hp}/${gameState.maxHp}`;
-        }
-        
-        if (monsterHpText) {
-            monsterHpText.textContent = `${monster.hp}/${monster.maxHp}`;
-        }
-        
-    } else {
-        // Hide combat modal
-        if (combatModal) {
-            combatModal.classList.add('hidden');
-            combatModal.classList.remove('flex');
-        }
-        
-        // Disable attack button
-        if (attackBtn) {
-            attackBtn.disabled = true;
-            attackBtn.classList.add('opacity-50', 'cursor-not-allowed');
-        }
+  const attackBtn = document.getElementById("attack-button");
+  const combatModal = document.getElementById("combat-modal");
+
+  if (room && room.monsters && room.monsters.length > 0) {
+    const monster = room.monsters[0];
+
+    // Show combat modal
+    if (combatModal) {
+      combatModal.classList.remove("hidden");
+      combatModal.classList.add("flex");
     }
+
+    // Enable attack button
+    if (attackBtn) {
+      attackBtn.disabled = false;
+      attackBtn.classList.remove("opacity-50", "cursor-not-allowed");
+    }
+
+    // Update HP bars
+    updateHPBar("player-hp-bar", gameState.hp, gameState.maxHp);
+    updateHPBar("monster-hp-bar", monster.hp, monster.maxHp);
+
+    // Update HP text
+    const playerHpText = document.getElementById("player-hp-bar-text");
+    const monsterHpText = document.getElementById("monster-hp-bar-text");
+
+    if (playerHpText) {
+      playerHpText.textContent = `${gameState.hp}/${gameState.maxHp}`;
+    }
+
+    if (monsterHpText) {
+      monsterHpText.textContent = `${monster.hp}/${monster.maxHp}`;
+    }
+  } else {
+    // Hide combat modal
+    if (combatModal) {
+      combatModal.classList.add("hidden");
+      combatModal.classList.remove("flex");
+    }
+
+    // Disable attack button
+    if (attackBtn) {
+      attackBtn.disabled = true;
+      attackBtn.classList.add("opacity-50", "cursor-not-allowed");
+    }
+  }
 }
 
 function updateHPBar(barId, currentHP, maxHP) {
-    const bar = document.getElementById(barId);
-    if (!bar) return;
-    
-    const percentage = Math.max(0, Math.min(100, (currentHP / maxHP) * 100));
-    bar.style.width = `${percentage}%`;
-    
-    // Add color coding based on HP percentage
-    if (percentage > 60) {
-        bar.classList.remove('bg-game-danger', 'bg-game-warning');
-        bar.classList.add('bg-game-success');
-    } else if (percentage > 30) {
-        bar.classList.remove('bg-game-success', 'bg-game-danger');
-        bar.classList.add('bg-game-warning');
-    } else {
-        bar.classList.remove('bg-game-success', 'bg-game-warning');
-        bar.classList.add('bg-game-danger');
-    }
+  const bar = document.getElementById(barId);
+  if (!bar) return;
+
+  const percentage = Math.max(0, Math.min(100, (currentHP / maxHP) * 100));
+  bar.style.width = `${percentage}%`;
+
+  // Add color coding based on HP percentage
+  if (percentage > 60) {
+    bar.classList.remove("bg-game-danger", "bg-game-warning");
+    bar.classList.add("bg-game-success");
+  } else if (percentage > 30) {
+    bar.classList.remove("bg-game-success", "bg-game-danger");
+    bar.classList.add("bg-game-warning");
+  } else {
+    bar.classList.remove("bg-game-success", "bg-game-warning");
+    bar.classList.add("bg-game-danger");
+  }
 }
 
 export function updateMapDisplay(grid) {
-    const mapGrid = document.getElementById('map-grid');
-    if (!grid || !mapGrid) return;
-    
-    // Create a more visually appealing map
-    let mapText = '';
-    
-    if (Array.isArray(grid)) {
-        mapText = grid.join('\n');
-    } else if (typeof grid === 'string') {
-        mapText = grid;
-    } else {
-        mapText = '지도를 불러올 수 없습니다.';
+  const mapGrid = document.getElementById("map-grid");
+  if (!grid || !mapGrid) return;
+
+  // Create a more visually appealing map
+  let mapText = "";
+
+  if (Array.isArray(grid)) {
+    mapText = grid.join("\n");
+  } else if (typeof grid === "string") {
+    mapText = grid;
+  } else {
+    mapText = "지도를 불러올 수 없습니다.";
+  }
+
+  mapGrid.textContent = mapText;
+
+  // Also update mini-map if it exists
+  const miniMap = document.getElementById("mini-map");
+  if (miniMap) {
+    const placeholder = miniMap.querySelector(".map-placeholder");
+    if (placeholder) {
+      placeholder.textContent = "지도가 업데이트되었습니다";
     }
-    
-    mapGrid.textContent = mapText;
-    
-    // Also update mini-map if it exists
-    const miniMap = document.getElementById('mini-map');
-    if (miniMap) {
-        const placeholder = miniMap.querySelector('.map-placeholder');
-        if (placeholder) {
-            placeholder.textContent = '지도가 업데이트되었습니다';
-        }
-    }
+  }
 }
 
 export function toggleMap() {
-    const mapDiv = document.getElementById('map-display');
-    if (!mapDiv) return;
-    
-    const isVisible = !mapDiv.classList.contains('hidden');
-    if (isVisible) {
-        mapDiv.classList.add('hidden');
-        mapDiv.classList.remove('flex');
-    } else {
-        mapDiv.classList.remove('hidden');
-        mapDiv.classList.add('flex');
-    }
+  const mapDiv = document.getElementById("map-display");
+  if (!mapDiv) return;
+
+  const isVisible = !mapDiv.classList.contains("hidden");
+  if (isVisible) {
+    mapDiv.classList.add("hidden");
+    mapDiv.classList.remove("flex");
+  } else {
+    mapDiv.classList.remove("hidden");
+    mapDiv.classList.add("flex");
+  }
 }
 
 // Additional UI utility functions
-export function showNotification(message, type = 'info') {
-    const notification = document.createElement('div');
-    notification.className = `notification notification-${type}`;
-    notification.textContent = message;
-    
-    // Add notification styles
-    notification.style.cssText = `
+export function showNotification(message, type = "info") {
+  const notification = document.createElement("div");
+  notification.className = `notification notification-${type}`;
+  notification.textContent = message;
+
+  // Add notification styles
+  notification.style.cssText = `
         position: fixed;
         top: 20px;
         right: 20px;
@@ -211,59 +226,59 @@ export function showNotification(message, type = 'info') {
         animation: slideIn 0.3s ease-out;
         max-width: 300px;
     `;
-    
-    document.body.appendChild(notification);
-    
-    // Remove after 3 seconds
+
+  document.body.appendChild(notification);
+
+  // Remove after 3 seconds
+  setTimeout(() => {
+    notification.style.animation = "slideOut 0.3s ease-in";
     setTimeout(() => {
-        notification.style.animation = 'slideOut 0.3s ease-in';
-        setTimeout(() => {
-            if (notification.parentNode) {
-                notification.parentNode.removeChild(notification);
-            }
-        }, 300);
-    }, 3000);
+      if (notification.parentNode) {
+        notification.parentNode.removeChild(notification);
+      }
+    }, 300);
+  }, 3000);
 }
 
 export function updatePlayerStats() {
-    const stats = {
-        hp: gameState.hp || 100,
-        maxHp: gameState.maxHp || 100,
-        level: gameState.level || 1,
-        exp: gameState.exp || 0,
-        expToNext: gameState.expToNext || 100,
-        attack: gameState.attack || 10,
-        defense: gameState.defense || 5,
-        gold: gameState.gold || 0
-    };
-    
-    // Update all stat elements
-    Object.keys(stats).forEach(stat => {
-        const element = document.getElementById(`player-${stat}`);
-        if (element) {
-            if (stat === 'hp') {
-                element.textContent = `${stats.hp}/${stats.maxHp}`;
-            } else if (stat === 'exp') {
-                element.textContent = `${stats.exp}/${stats.expToNext}`;
-            } else {
-                element.textContent = stats[stat];
-            }
-        }
-    });
+  const stats = {
+    hp: gameState.hp || 100,
+    maxHp: gameState.maxHp || 100,
+    level: gameState.level || 1,
+    exp: gameState.exp || 0,
+    expToNext: gameState.expToNext || 100,
+    attack: gameState.attack || 10,
+    defense: gameState.defense || 5,
+    gold: gameState.gold || 0,
+  };
+
+  // Update all stat elements
+  Object.keys(stats).forEach((stat) => {
+    const element = document.getElementById(`player-${stat}`);
+    if (element) {
+      if (stat === "hp") {
+        element.textContent = `${stats.hp}/${stats.maxHp}`;
+      } else if (stat === "exp") {
+        element.textContent = `${stats.exp}/${stats.expToNext}`;
+      } else {
+        element.textContent = stats[stat];
+      }
+    }
+  });
 }
 
-export function animateElement(elementId, animation = 'pulse') {
-    const element = document.getElementById(elementId);
-    if (!element) return;
-    
-    element.style.animation = `${animation} 0.5s ease-in-out`;
-    setTimeout(() => {
-        element.style.animation = '';
-    }, 500);
+export function animateElement(elementId, animation = "pulse") {
+  const element = document.getElementById(elementId);
+  if (!element) return;
+
+  element.style.animation = `${animation} 0.5s ease-in-out`;
+  setTimeout(() => {
+    element.style.animation = "";
+  }, 500);
 }
 
 // Add CSS for notifications
-const style = document.createElement('style');
+const style = document.createElement("style");
 style.textContent = `
     @keyframes slideIn {
         from {


### PR DESCRIPTION
## 요약
- 게임 인터페이스를 단일 화면에 맞도록 헤더, 상태 카드, 미니맵, 로그, 하단 명령 패널로 재구성했습니다.
- 상호작용 전용 모달을 추가하고 인벤토리/방 아이템을 다이얼로그 기반으로 확인하도록 개선했습니다.
- UI 상태 갱신 로직을 정리하여 상호작용 버튼, 진행도 바, 모달 정보 등이 즉시 반영되도록 업데이트했습니다.

## 테스트
- `npx prettier --check index.html main.js uiManager.js`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ce7fbefcb8832ca7b143b92eb101b6